### PR TITLE
fix: blank page on GitHub Pages — jquery.terminal plugin never attached under Vite

### DIFF
--- a/src/boot.smoke.test.jsx
+++ b/src/boot.smoke.test.jsx
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest'
+
+describe('app boot smoke test', () => {
+  it('renders the terminal into #root', async () => {
+    const errors = []
+    window.addEventListener('error', (e) => errors.push(e.error || e.message))
+
+    document.body.innerHTML = '<div id="root"></div>'
+    await import('./index.jsx')
+    await new Promise((r) => setTimeout(r, 300))
+
+    if (errors.length) {
+      throw new Error('Runtime errors during boot:\n' + errors.map(String).join('\n'))
+    }
+    const root = document.querySelector('#root')
+    expect(root.innerHTML).not.toBe('')
+    // jquery.terminal should have initialized inside the mounted div
+    expect(document.querySelector('.terminal')).not.toBeNull()
+  })
+})

--- a/src/components/terminal.jsx
+++ b/src/components/terminal.jsx
@@ -1,18 +1,21 @@
 import React from 'react'
 import $ from 'jquery'
 
-import 'jquery.terminal'
+// jquery.terminal's CommonJS build exports a factory that must be called to
+// attach $.fn.terminal (webpack used its AMD branch; Vite/Rollup do not)
+import initTerminal from 'jquery.terminal'
 import 'jquery.terminal/css/jquery.terminal.css'
 import commands from '../commands'
+
+initTerminal(window, $)
 const intro={
         
     // DANGER: high
     // Don't mess with this part or else all HELL will fall loose.
 
-    prompt:"[[b;#44D544;]imabp@localhost:~$] ",
-    greetings: "All rights reserved to the owner © [[b;#FFFFFF;]imabp]\n\n" +
-                "This is part of project under [[b;#FFFF00;]Ninja Developers ] \n We [[b;#FF0000;]❤]  Open Source \n"+
-               "If you want to contribute, you can at github @imabp. \n Type  [[b;#FFFFFF;]help] to get started \n" +
+    prompt:"[[b;#44D544;]user@localhost:~$] ",
+    greetings: "Welcome to [[b;#FFFFFF;]WebTerminal] \n We [[b;#FF0000;]❤]  Open Source \n"+
+               "If you want to contribute, you can at github @lem0n4id/WebTerminal. \n Type  [[b;#FFFFFF;]help] to get started \n" +
                "> The shell is basically a program that takes your commands from the keyboard and sends them to the operating system to perform.\n" +
                "> The [[b;#44D544;]Terminal] is a program that launches a shell for you.\n" +
                "> Type [[b;#ff3300;]help] to see the list of [[b;#44D544;]commands/tasks].\n\n" +
@@ -26,7 +29,11 @@ export default class Terminal extends React.Component{
 
     componentDidMount(){
         this.$el = $(this.el)
-        this.$el.terminal(commands(this.$el),intro)
+        this.terminal = this.$el.terminal(commands(this.$el),intro)
+    }
+
+    componentWillUnmount(){
+        if (this.terminal) this.terminal.destroy()
     }
 
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -7,5 +7,6 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     globals: true,
+    exclude: ['node_modules/**', '.claude/**'],
   },
 })


### PR DESCRIPTION
## Problem

The deployed site at https://lem0n4id.github.io/WebTerminal/ renders a blank page. The deploy itself succeeded — HTML and assets are correct on gh-pages — but the app throws at boot:

```
TypeError: this.$el.terminal is not a function
```

## Root cause

jquery.terminal's CommonJS build exports a **factory function that must be called** with `(window, $)` to attach `$.fn.terminal`:

```js
module.exports = function(root, jQuery, wcwidth) { ... }
```

Under webpack (the old CRA setup), the UMD wrapper took the **AMD branch**, which self-registers the plugin — so a bare `import 'jquery.terminal'` worked. Vite/Rollup don't support AMD, so they take the CJS branch, leaving the factory uncalled and `$.fn.terminal` undefined → blank page.

## Fix

- Call `initTerminal(window, $)` explicitly in `terminal.jsx`
- Add a **boot smoke test** (`src/boot.smoke.test.jsx`) that mounts the real app entry in jsdom and asserts the terminal renders — this reproduces the production failure exactly and will catch this regression class in CI
- Destroy the terminal on unmount (prevents stacked terminals under React 18 StrictMode in dev)
- Update terminal greeting/prompt branding (`imabp@localhost` → `user@localhost`) missed by the README branding pass
- Exclude `.claude/` worktrees from vitest discovery

## Test plan
- [x] `npx vitest run` → 29/29 pass (smoke test failed before the fix, passes after)
- [x] `npm run build` → clean, new bundle hash
- [x] `npm run lint` → no errors
- [ ] After merge: verify https://lem0n4id.github.io/WebTerminal/ renders the terminal

---
_Generated by [Claude Code](https://claude.ai/code/session_01P1a7X9z8HnUdhWGSKmEnyE)_