### PR TITLE
test: add Playwright e2e sanity tests and gate deploys on them

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -4,7 +4,37 @@ on:
     branches:
       - master
 jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install chromium --with-deps
+
+      - name: Run e2e tests
+        run: npm run test:e2e
+
+      - name: Upload Playwright report
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7
+
   build-and-deploy:
+    needs: e2e
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,3 +27,32 @@ jobs:
 
       - name: Test
         run: npm run test
+
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install chromium --with-deps
+
+      - name: Run e2e tests
+        run: npm run test:e2e
+
+      - name: Upload Playwright report
+        uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,8 @@ yarn-error.log*
 
 # Claude Code worktrees (temporary agent workspaces)
 .claude/worktrees/
+
+# playwright
+/test-results
+/playwright-report
+/blob-report

--- a/e2e/sanity.spec.js
+++ b/e2e/sanity.spec.js
@@ -1,0 +1,73 @@
+import { test, expect } from '@playwright/test'
+
+// Basic sanity tests against the production build. These exercise the real
+// jquery.terminal boot path — the class of failure that unit tests on the
+// pure-logic modules cannot catch (e.g. the blank-page plugin-attach bug).
+
+async function run(page, command) {
+  await page.keyboard.type(command)
+  await page.keyboard.press('Enter')
+}
+
+test.beforeEach(async ({ page }) => {
+  await page.goto('./')
+  await expect(page.locator('.terminal')).toBeVisible()
+  await page.locator('.terminal').click()
+})
+
+test('terminal boots and shows the greeting', async ({ page }) => {
+  const output = page.locator('.terminal-output')
+  await expect(output).toContainText('WebTerminal')
+  await expect(output).toContainText('Type')
+  await expect(page.locator('.terminal')).toContainText('user@localhost')
+})
+
+test('echo prints back its argument', async ({ page }) => {
+  await run(page, 'echo hello-from-e2e')
+  await expect(page.locator('.terminal-output')).toContainText('hello-from-e2e')
+})
+
+test('help lists commands and tracks completion', async ({ page }) => {
+  await run(page, 'echo done')
+  await run(page, 'help')
+  const output = page.locator('.terminal-output')
+  await expect(output).toContainText('ls')
+  await expect(output).toContainText('mkdir')
+  await expect(output).toContainText('cat')
+  // echo was run above, so at least one command must be marked completed
+  await expect(output).toContainText('Completed')
+})
+
+test('filesystem navigation works end-to-end', async ({ page }) => {
+  const output = page.locator('.terminal-output')
+
+  await run(page, 'ls')
+  await expect(output).toContainText('Documents')
+  await expect(output).toContainText('readme.txt')
+
+  await run(page, 'cd Documents')
+  await run(page, 'pwd')
+  await expect(output).toContainText('/home/user/Documents')
+
+  await run(page, 'cd ..')
+  await run(page, 'cat readme.txt')
+  await expect(output).toContainText('Welcome to WebTerminal')
+})
+
+test('mkdir creates a directory visible to ls', async ({ page }) => {
+  const output = page.locator('.terminal-output')
+
+  await run(page, 'mkdir e2e-dir')
+  await run(page, 'ls')
+  await expect(output).toContainText('e2e-dir')
+})
+
+test('unknown command reports an error instead of crashing', async ({ page }) => {
+  await run(page, 'definitely-not-a-command')
+  await expect(page.locator('.terminal-output')).toContainText(
+    /command .* not found|definitely-not-a-command/i
+  )
+  // terminal still responsive afterwards
+  await run(page, 'echo still-alive')
+  await expect(page.locator('.terminal-output')).toContainText('still-alive')
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "react-dom": "^18.3.1"
       },
       "devDependencies": {
+        "@playwright/test": "^1.60.0",
         "@vitejs/plugin-react": "^4.3.4",
         "@vitest/ui": "^2.1.8",
         "eslint": "^8.57.1",
@@ -1224,6 +1225,22 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@polka/url": {
@@ -3565,6 +3582,21 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -5079,6 +5111,38 @@
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "vite build",
     "preview": "vite preview",
     "test": "vitest run",
+    "test:e2e": "playwright test",
     "lint": "eslint src --ext .js,.jsx"
   },
   "dependencies": {
@@ -18,6 +19,7 @@
     "react-dom": "^18.3.1"
   },
   "devDependencies": {
+    "@playwright/test": "^1.60.0",
     "@vitejs/plugin-react": "^4.3.4",
     "@vitest/ui": "^2.1.8",
     "eslint": "^8.57.1",
@@ -28,7 +30,15 @@
     "vitest": "^2.1.8"
   },
   "browserslist": {
-    "production": [">0.2%", "not dead", "not op_mini all"],
-    "development": ["last 1 chrome version", "last 1 firefox version", "last 1 safari version"]
+    "production": [
+      ">0.2%",
+      "not dead",
+      "not op_mini all"
+    ],
+    "development": [
+      "last 1 chrome version",
+      "last 1 firefox version",
+      "last 1 safari version"
+    ]
   }
 }

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,22 @@
+import { defineConfig } from '@playwright/test'
+
+export default defineConfig({
+  testDir: './e2e',
+  timeout: 30_000,
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  reporter: process.env.CI ? 'github' : 'list',
+  use: {
+    // Tests run against the production build served under the GitHub Pages
+    // base path, so base-path regressions are caught too
+    baseURL: 'http://localhost:4173/WebTerminal/',
+    trace: 'on-first-retry',
+  },
+  webServer: {
+    command: 'npm run build && npm run preview',
+    url: 'http://localhost:4173/WebTerminal/',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+})

--- a/src/boot.smoke.test.jsx
+++ b/src/boot.smoke.test.jsx
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest'
+
+describe('app boot smoke test', () => {
+  it('renders the terminal into #root', async () => {
+    const errors = []
+    window.addEventListener('error', (e) => errors.push(e.error || e.message))
+
+    document.body.innerHTML = '<div id="root"></div>'
+    await import('./index.jsx')
+    await new Promise((r) => setTimeout(r, 300))
+
+    if (errors.length) {
+      throw new Error('Runtime errors during boot:\n' + errors.map(String).join('\n'))
+    }
+    const root = document.querySelector('#root')
+    expect(root.innerHTML).not.toBe('')
+    // jquery.terminal should have initialized inside the mounted div
+    expect(document.querySelector('.terminal')).not.toBeNull()
+  })
+})

--- a/src/components/terminal.jsx
+++ b/src/components/terminal.jsx
@@ -1,18 +1,21 @@
 import React from 'react'
 import $ from 'jquery'
 
-import 'jquery.terminal'
+// jquery.terminal's CommonJS build exports a factory that must be called to
+// attach $.fn.terminal (webpack used its AMD branch; Vite/Rollup do not)
+import initTerminal from 'jquery.terminal'
 import 'jquery.terminal/css/jquery.terminal.css'
 import commands from '../commands'
+
+initTerminal(window, $)
 const intro={
         
     // DANGER: high
     // Don't mess with this part or else all HELL will fall loose.
 
-    prompt:"[[b;#44D544;]imabp@localhost:~$] ",
-    greetings: "All rights reserved to the owner © [[b;#FFFFFF;]imabp]\n\n" +
-                "This is part of project under [[b;#FFFF00;]Ninja Developers ] \n We [[b;#FF0000;]❤]  Open Source \n"+
-               "If you want to contribute, you can at github @imabp. \n Type  [[b;#FFFFFF;]help] to get started \n" +
+    prompt:"[[b;#44D544;]user@localhost:~$] ",
+    greetings: "Welcome to [[b;#FFFFFF;]WebTerminal] \n We [[b;#FF0000;]❤]  Open Source \n"+
+               "If you want to contribute, you can at github @lem0n4id/WebTerminal. \n Type  [[b;#FFFFFF;]help] to get started \n" +
                "> The shell is basically a program that takes your commands from the keyboard and sends them to the operating system to perform.\n" +
                "> The [[b;#44D544;]Terminal] is a program that launches a shell for you.\n" +
                "> Type [[b;#ff3300;]help] to see the list of [[b;#44D544;]commands/tasks].\n\n" +
@@ -26,7 +29,11 @@ export default class Terminal extends React.Component{
 
     componentDidMount(){
         this.$el = $(this.el)
-        this.$el.terminal(commands(this.$el),intro)
+        this.terminal = this.$el.terminal(commands(this.$el),intro)
+    }
+
+    componentWillUnmount(){
+        if (this.terminal) this.terminal.destroy()
     }
 
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -7,5 +7,6 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     globals: true,
+    exclude: ['node_modules/**', '.claude/**'],
   },
 })

--- a/vite.config.js
+++ b/vite.config.js
@@ -7,6 +7,6 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     globals: true,
-    exclude: ['node_modules/**', '.claude/**'],
+    exclude: ['node_modules/**', '.claude/**', 'e2e/**'],
   },
 })


### PR DESCRIPTION
## Summary

Adds Playwright e2e sanity tests and wires them into both CI and the deploy pipeline.

**⚠️ Depends on #5** — merge that first (this branch includes its commit; once #5 lands, this PR will show only the e2e changes). The e2e tests would fail against current master because of the blank-page bug #5 fixes.

### Tests (6, in `e2e/sanity.spec.js`)
- Terminal boots and shows the greeting
- `echo` prints back its argument
- `help` lists commands and tracks completion status
- Filesystem navigation end-to-end: `ls` → `cd Documents` → `pwd` → `cd ..` → `cat readme.txt`
- `mkdir` creates a directory visible to `ls`
- Unknown command reports an error and the terminal stays responsive

### Why this catches what unit tests can't
The tests run against the **production build** served by `vite preview` under the `/WebTerminal/` base path — the same artifact GitHub Pages serves. They exercise the real jquery.terminal boot path (the blank-page bug from #5 would have failed every one of these) and would also catch base-path misconfigurations.

### CI/CD integration
- **`ci.yml`**: new `e2e` job on PRs (installs Chromium, runs `npm run test:e2e`, uploads the Playwright report as an artifact on failure)
- **`build_and_deploy.yml`**: deploy job now `needs: e2e` — master never publishes to Pages unless the sanity suite passes against the build

### Verified locally
- `npx playwright test --list` → 6 tests discovered, config valid
- `vite preview` serves HTTP 200 at the configured baseURL with correct asset paths
- Vitest discovery unaffected (29 unit tests still pass; `e2e/` excluded)
- Both workflow YAMLs validated

Browser execution itself couldn't run in my sandbox (Playwright CDN blocked by network policy) — the `e2e` CI job on this PR is the live verification; check it before merging.

---
_Generated by [Claude Code](https://claude.ai/code/session_01P1a7X9z8HnUdhWGSKmEnyE)_