### PR TITLE
ci: cache Playwright browsers and skip apt — cuts e2e setup from 29s to ~3s

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -19,8 +19,22 @@ jobs:
       - name: Install
         run: npm ci
 
+      - name: Get Playwright version
+        id: playwright-version
+        run: echo "version=$(node -p "require('@playwright/test/package.json').version")" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
+
+      # Headless shell only (tests are headless); ubuntu-latest runners ship
+      # with Chrome so its shared libraries are already present — no apt step
       - name: Install Playwright browsers
-        run: npx playwright install chromium --with-deps
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: npx playwright install chromium --only-shell
 
       - name: Run e2e tests
         run: npm run test:e2e

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,8 +43,22 @@ jobs:
       - name: Install
         run: npm ci
 
+      - name: Get Playwright version
+        id: playwright-version
+        run: echo "version=$(node -p "require('@playwright/test/package.json').version")" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
+
+      # Headless shell only (tests are headless); ubuntu-latest runners ship
+      # with Chrome so its shared libraries are already present — no apt step
       - name: Install Playwright browsers
-        run: npx playwright install chromium --with-deps
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: npx playwright install chromium --only-shell
 
       - name: Run e2e tests
         run: npm run test:e2e


### PR DESCRIPTION
## Why

Looking at the latest `Build and Deploy` run, the e2e job took ~51 s and **29 s of that was `npx playwright install chromium --with-deps`** — re-downloading the browser and running apt on every single run.

For context on the alternatives considered:
- **Docker container image**: the Playwright image is ~2 GB; pulling it would take longer than the 29 s it saves at this repo's scale
- **Node 24 hang bug**: doesn't apply — CI is pinned to Node 22
- **Caching + trimming the install** (this PR): the right fit

## What changed (both `ci.yml` and `build_and_deploy.yml` e2e jobs)

1. **Cache `~/.cache/ms-playwright`** keyed on `runner.os` + the installed `@playwright/test` version — cache hits skip the browser download entirely, and bumping the Playwright dependency automatically re-primes the cache
2. **`--only-shell` on cache miss** — tests run headless, so only the Chromium headless shell (~half the download) is needed
3. **Dropped `--with-deps`** — no more apt-get; `ubuntu-latest` runners ship with Chrome, so all required shared libraries are already present

## Expected effect

- First run (cache miss): faster than before (smaller download, no apt)
- Subsequent runs: browser install step drops from ~29 s to ~2-3 s cache restore

## Verification

The e2e job on this PR runs with the updated workflow file — a green check here is the live proof (this run is the cache-miss path; the next PR gets the cache hit).

---
_Generated by [Claude Code](https://claude.ai/code/session_01P1a7X9z8HnUdhWGSKmEnyE)_