### PR TITLE
feat: persist learner progress in localStorage

### DIFF
--- a/src/commands/basic.js
+++ b/src/commands/basic.js
@@ -72,6 +72,11 @@ let basic = (context, counter, fs) => {
       context.echo('> [[b;#ff3300;]tty] prints the filename of the terminal connected to standard input.\n')
     },
 
+    reset: () => {
+      counter.resetProgress()
+      context.echo('Progress reset. Type [[b;#ff3300;]help] to see the task list.\n')
+    },
+
     about: () => {
       context.echo('> The shell is basically a program that takes your commands from the keyboard')
       context.echo('> and sends them to the operating system to perform.\n')

--- a/src/commands/commands.test.js
+++ b/src/commands/commands.test.js
@@ -5,6 +5,7 @@ describe('CounterService', () => {
   let counter
 
   beforeEach(() => {
+    window.localStorage.clear()
     counter = new CounterService()
   })
 
@@ -47,5 +48,52 @@ describe('CounterService', () => {
     expect(cmds).toContain('cp')
     expect(cmds).toContain('rm')
     expect(cmds).toContain('history')
+  })
+
+  it('progress persists across instances', () => {
+    counter.setDone('echo')
+    counter.setDone('pwd')
+    const fresh = new CounterService()
+    expect(fresh.getStatus('echo')).toContain('Completed')
+    expect(fresh.getStatus('pwd')).toContain('Completed')
+    expect(fresh.completedCount()).toBe(2)
+  })
+
+  it('corrupt JSON in localStorage is ignored', () => {
+    window.localStorage.setItem('webterminal:progress:v1', '{not valid json!!')
+    let fresh
+    expect(() => {
+      fresh = new CounterService()
+    }).not.toThrow()
+    expect(fresh.completedCount()).toBe(0)
+  })
+
+  it('non-object JSON in localStorage is ignored', () => {
+    window.localStorage.setItem('webterminal:progress:v1', '"just a string"')
+    const fresh = new CounterService()
+    expect(fresh.completedCount()).toBe(0)
+  })
+
+  it('unknown command keys in storage are ignored', () => {
+    window.localStorage.setItem(
+      'webterminal:progress:v1',
+      JSON.stringify({ echo: true, bogus: true, 'rm -rf /': true, toString: true })
+    )
+    const fresh = new CounterService()
+    expect(fresh.getStatus('echo')).toContain('Completed')
+    expect(fresh.allCommands()).not.toContain('bogus')
+    expect(fresh.allCommands()).not.toContain('rm -rf /')
+    expect(fresh.allCommands()).not.toContain('toString')
+    expect(fresh.completedCount()).toBe(1)
+  })
+
+  it('resetProgress marks everything undone and clears storage', () => {
+    counter.setDone('echo')
+    counter.setDone('ls')
+    counter.resetProgress()
+    expect(counter.completedCount()).toBe(0)
+    expect(window.localStorage.getItem('webterminal:progress:v1')).toBeNull()
+    const fresh = new CounterService()
+    expect(fresh.completedCount()).toBe(0)
   })
 })

--- a/src/commands/counter.service.js
+++ b/src/commands/counter.service.js
@@ -1,3 +1,5 @@
+import { loadProgress, saveProgress, clearProgress } from '../lib/storage'
+
 class CounterService {
   constructor() {
     this._commands = {
@@ -19,6 +21,12 @@ class CounterService {
       tty: false,
       history: false,
     }
+    const saved = loadProgress()
+    for (const name of Object.keys(saved)) {
+      if (Object.prototype.hasOwnProperty.call(this._commands, name)) {
+        this._commands[name] = Boolean(saved[name])
+      }
+    }
   }
 
   // Returns colored jquery.terminal markup
@@ -33,7 +41,15 @@ class CounterService {
   setDone(name) {
     if (name in this._commands) {
       this._commands[name] = true
+      saveProgress(this._commands)
     }
+  }
+
+  resetProgress() {
+    for (const name of Object.keys(this._commands)) {
+      this._commands[name] = false
+    }
+    clearProgress()
   }
 
   allCommands() {

--- a/src/lib/storage.js
+++ b/src/lib/storage.js
@@ -1,0 +1,28 @@
+const KEY = 'webterminal:progress:v1'
+
+export function loadProgress() {
+  try {
+    const raw = window.localStorage.getItem(KEY)
+    if (!raw) return {}
+    const parsed = JSON.parse(raw)
+    return typeof parsed === 'object' && parsed !== null ? parsed : {}
+  } catch {
+    return {}
+  }
+}
+
+export function saveProgress(progress) {
+  try {
+    window.localStorage.setItem(KEY, JSON.stringify(progress))
+  } catch {
+    // storage unavailable (private mode, quota) — progress just won't persist
+  }
+}
+
+export function clearProgress() {
+  try {
+    window.localStorage.removeItem(KEY)
+  } catch {
+    // ignore
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `src/lib/storage.js`, a safe wrapper around `localStorage` (`loadProgress` / `saveProgress` / `clearProgress`) under the key `webterminal:progress:v1`. It never throws when storage is unavailable (private mode, quota) or contains garbage.
- `CounterService` now loads saved progress in its constructor — applying only keys that are own properties of the built-in `_commands` map (unknown and prototype-inherited keys like `toString` from stale/corrupt storage are ignored) — and persists the map on every `setDone`.
- New `CounterService.resetProgress()` sets all commands back to not-done and clears storage.
- New `reset` terminal command in `basic.js` that calls `resetProgress()` (meta command — intentionally not added to the tracked `_commands` map).

## Tests
- Progress persists across `CounterService` instances
- Corrupt JSON and non-object JSON in storage are ignored without throwing
- Unknown / prototype-key entries in storage are ignored
- `resetProgress()` marks everything undone and clears storage
- Existing tests kept green via `window.localStorage.clear()` in `beforeEach`

## Verification
- `npx vitest run`: 34/34 tests pass (fs, commands, boot smoke)
- `npm run build`: succeeds
- `npm run lint`: clean
- Browser e2e (Playwright) could not run in the sandbox — it will run in CI on this PR.

https://claude.ai/code/session_01P1a7X9z8HnUdhWGSKmEnyE

---
_Generated by [Claude Code](https://claude.ai/code/session_01P1a7X9z8HnUdhWGSKmEnyE)_