### PR TITLE
feat: tab completion for commands and paths

### DIFF
--- a/e2e/completion.spec.js
+++ b/e2e/completion.spec.js
@@ -1,0 +1,13 @@
+import { test, expect } from '@playwright/test'
+
+test('tab completes a command name prefix', async ({ page }) => {
+  await page.goto('./')
+  await expect(page.locator('.terminal')).toBeVisible()
+  await page.locator('.terminal').click()
+
+  await page.keyboard.type('ec')
+  await page.keyboard.press('Tab')
+
+  // jquery.terminal renders the current input line inside the .cmd element
+  await expect(page.locator('.cmd')).toContainText('echo')
+})

--- a/src/commands/index.js
+++ b/src/commands/index.js
@@ -8,7 +8,17 @@ const commands = context => {
   const fs = new FileSystem()
   const b = basic(context, counter, fs)
   const f = fs_commands(context, counter, fs)
-  return { ...b, ...f }
+  const result = { ...b, ...f }
+  // Expose the shared FileSystem for tab completion. Non-enumerable so it
+  // never shows up as a command, and configurable so the consumer can delete
+  // it after reading (jquery.terminal resolves typed commands via plain
+  // property access, so a lingering object property would be reachable).
+  Object.defineProperty(result, '__fs', {
+    value: fs,
+    enumerable: false,
+    configurable: true,
+  })
+  return result
 }
 
 export default commands

--- a/src/components/terminal.jsx
+++ b/src/components/terminal.jsx
@@ -6,6 +6,7 @@ import $ from 'jquery'
 import initTerminal from 'jquery.terminal'
 import 'jquery.terminal/css/jquery.terminal.css'
 import commands from '../commands'
+import { getCompletions } from '../lib/completion'
 
 initTerminal(window, $)
 const intro={
@@ -29,7 +30,19 @@ export default class Terminal extends React.Component{
 
     componentDidMount(){
         this.$el = $(this.el)
-        this.terminal = this.$el.terminal(commands(this.$el),intro)
+        const interpreter = commands(this.$el)
+        const fs = interpreter.__fs // shared FileSystem (see src/commands/index.js)
+        delete interpreter.__fs // keep the interpreter a pure command map
+        const names = Object.keys(interpreter)
+        this.terminal = this.$el.terminal(interpreter, {
+            ...intro,
+            // Tab completion: jquery.terminal passes the current token, but the
+            // pure logic works off the line so far, so fetch it from the terminal
+            completion: function(string, callback) {
+                const line = this.before_cursor(false)
+                callback(getCompletions(line, { commands: names, fs }))
+            },
+        })
     }
 
     componentWillUnmount(){

--- a/src/lib/completion.js
+++ b/src/lib/completion.js
@@ -1,0 +1,50 @@
+// Pure, terminal-agnostic tab-completion logic. Kept free of any
+// jquery.terminal / xterm.js specifics so it survives terminal migrations.
+
+/**
+ * Compute completion candidates for the last token of an input line.
+ *
+ * - First token still being typed (leading whitespace ignored): candidates
+ *   come from `ctx.commands` filtered by prefix. Multi-word entries in the
+ *   command list (e.g. 'cd ..') are skipped — they are not real command
+ *   names and would pollute matches for plain 'cd'.
+ * - After the first token: the last token is treated as a path and
+ *   candidates come from `ctx.fs.ls()` (current directory) filtered by
+ *   prefix. A trailing space means an empty prefix, i.e. all entries.
+ *
+ * Matching is case-sensitive, like a real shell.
+ *
+ * @param {string} line - full input line so far (e.g. 'cd Doc')
+ * @param {{ commands: string[], fs: { ls: () => string[] } }} ctx
+ * @returns {string[]} candidate completions for the LAST token of line
+ */
+export function getCompletions(line, ctx) {
+  try {
+    if (typeof line !== 'string' || !ctx) return []
+
+    const prefix = line.slice(line.lastIndexOf(' ') + 1)
+    // First token still being typed (nothing but whitespace before it, like a
+    // shell ignoring leading spaces): complete command names
+    const firstToken = line.slice(0, line.length - prefix.length).trim() === ''
+
+    if (firstToken) {
+      const commands = Array.isArray(ctx.commands) ? ctx.commands : []
+      return commands.filter(
+        name =>
+          typeof name === 'string' &&
+          !name.includes(' ') &&
+          name.startsWith(prefix)
+      )
+    }
+
+    // Past the first token: complete file/directory names from the cwd
+    if (!ctx.fs || typeof ctx.fs.ls !== 'function') return []
+    const entries = ctx.fs.ls()
+    if (!Array.isArray(entries)) return []
+    return entries.filter(
+      name => typeof name === 'string' && name.startsWith(prefix)
+    )
+  } catch {
+    return []
+  }
+}

--- a/src/lib/completion.test.js
+++ b/src/lib/completion.test.js
@@ -1,0 +1,97 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { getCompletions } from './completion.js'
+import FileSystem from './fs.js'
+
+const COMMANDS = ['echo', 'pwd', 'ls', 'cd', 'cat', 'clear', 'cp', 'help']
+
+describe('getCompletions', () => {
+  let fs
+  let ctx
+
+  beforeEach(() => {
+    fs = new FileSystem()
+    ctx = { commands: COMMANDS, fs }
+  })
+
+  describe('command-name completion (first token)', () => {
+    it('completes a command prefix', () => {
+      expect(getCompletions('ec', ctx)).toEqual(['echo'])
+    })
+
+    it('returns all commands for an empty line', () => {
+      expect(getCompletions('', ctx)).toEqual(COMMANDS)
+    })
+
+    it('returns multiple matches sharing a prefix', () => {
+      expect(getCompletions('c', ctx)).toEqual(['cd', 'cat', 'clear', 'cp'])
+    })
+
+    it('matches case-sensitively', () => {
+      expect(getCompletions('EC', ctx)).toEqual([])
+    })
+
+    it('returns [] when nothing matches', () => {
+      expect(getCompletions('zzz', ctx)).toEqual([])
+    })
+
+    it('ignores leading whitespace, like a shell', () => {
+      expect(getCompletions(' ec', ctx)).toEqual(['echo'])
+    })
+
+    it('skips multi-word command-list entries so they do not break plain prefixes', () => {
+      // Some command lists include variants like 'cd ..' or 'cd ~'; these are
+      // not typeable command names, so completion ignores them entirely.
+      const withMultiWord = {
+        commands: ['cd', 'cd ..', 'cd ~', 'cat'],
+        fs,
+      }
+      expect(getCompletions('cd', withMultiWord)).toEqual(['cd'])
+      expect(getCompletions('c', withMultiWord)).toEqual(['cd', 'cat'])
+    })
+  })
+
+  describe('file completion (after the first token)', () => {
+    it('completes a file/dir prefix from the cwd', () => {
+      expect(getCompletions('cd Doc', ctx)).toEqual(['Documents'])
+    })
+
+    it('returns all cwd entries after a trailing space', () => {
+      expect(getCompletions('cat ', ctx)).toEqual([
+        'Documents',
+        'Downloads',
+        'readme.txt',
+      ])
+    })
+
+    it('completes the LAST token of a multi-argument line', () => {
+      expect(getCompletions('cp readme.txt Dow', ctx)).toEqual(['Downloads'])
+    })
+
+    it('reflects the current directory after cd', () => {
+      fs.cd('Documents')
+      expect(getCompletions('cat read', ctx)).toEqual([])
+      expect(getCompletions('ls ', ctx)).toEqual([])
+    })
+
+    it('returns [] when no entry matches', () => {
+      expect(getCompletions('cat zzz', ctx)).toEqual([])
+    })
+  })
+
+  describe('robustness — never throws', () => {
+    it('handles missing or malformed context', () => {
+      expect(getCompletions('ec', null)).toEqual([])
+      expect(getCompletions('ec', {})).toEqual([])
+      expect(getCompletions('cat r', {})).toEqual([])
+      expect(getCompletions('cat r', { commands: COMMANDS })).toEqual([])
+      expect(getCompletions('cat r', { fs: { ls: () => null } })).toEqual([])
+      expect(getCompletions('cat r', { fs: { ls: () => { throw new Error('boom') } } })).toEqual([])
+    })
+
+    it('handles non-string lines', () => {
+      expect(getCompletions(null, ctx)).toEqual([])
+      expect(getCompletions(undefined, ctx)).toEqual([])
+      expect(getCompletions(42, ctx)).toEqual([])
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Adds Tab completion for command names and file/directory names.
- `src/lib/completion.js` — pure, terminal-agnostic `getCompletions(line, ctx)`: completes the first token from the command list (multi-word entries like `cd ..` are skipped; leading whitespace ignored), and later tokens from `fs.ls()` of the current directory. Case-sensitive prefix matching; never throws. Kept terminal-agnostic so the upcoming xterm.js migration can reuse it as-is.
- `src/components/terminal.jsx` — thin jquery.terminal adapter via the `completion` option; uses `this.before_cursor(false)` so completion works at the cursor position.
- `src/commands/index.js` — exposes the shared `FileSystem` as a non-enumerable, configurable `__fs` property; the component reads it and then deletes it so the interpreter stays a pure command map (jquery.terminal resolves typed commands via property access).
- `src/lib/completion.test.js` — 14 vitest cases (prefix/empty-prefix command completion, file completion after a command and after a trailing space, multi-word command-list entries, cwd changes, robustness/never-throws).
- `e2e/completion.spec.js` — one Playwright test: type `ec`, press Tab, expect `echo` in the input line.

## Testing
- `npx vitest run`: 43/43 pass
- `npm run build`: succeeds
- `npm run lint`: clean
- `npx playwright test --list`: all specs parse, new test listed
- Browser e2e could not run locally (sandbox blocks browsers) — CI runs the Playwright suite on this PR.

https://claude.ai/code/session_01P1a7X9z8HnUdhWGSKmEnyE

---
_Generated by [Claude Code](https://claude.ai/code/session_01P1a7X9z8HnUdhWGSKmEnyE)_