### PR TITLE
feat(mobile): helper key bar and command suggestion chips

### DIFF
--- a/src/commands/counter.service.js
+++ b/src/commands/counter.service.js
@@ -57,6 +57,12 @@ class CounterService {
     return Object.keys(this._commands)
   }
 
+  // Not-yet-completed commands that are directly typeable as a single word
+  // (excludes multi-word pseudo-entries like 'cd ..')
+  pendingCommands() {
+    return Object.keys(this._commands).filter((name) => !this._commands[name] && !name.includes(' '))
+  }
+
   completedCount() {
     return Object.values(this._commands).filter(Boolean).length
   }

--- a/src/commands/index.js
+++ b/src/commands/index.js
@@ -4,9 +4,9 @@ import CounterService from './counter.service'
 import FileSystem from '../lib/fs'
 
 // `fs` can be injected so the caller (e.g. the terminal's tab completion)
-// shares the same filesystem instance as the commands
-const commands = (context, fs = new FileSystem()) => {
-  const counter = new CounterService()
+// shares the same filesystem instance as the commands; `counter` can be
+// injected so the caller (e.g. the mobile command chips) shares progress
+const commands = (context, fs = new FileSystem(), counter = new CounterService()) => {
   const b = basic(context, counter, fs)
   const f = fs_commands(context, counter, fs)
   return { ...b, ...f }

--- a/src/components/CommandChips.jsx
+++ b/src/components/CommandChips.jsx
@@ -1,0 +1,35 @@
+import React, { useMemo } from 'react'
+
+const MAX_CHIPS = 4
+
+// Educational command suggestion chips (the Swift Playgrounds
+// insert-don't-run pattern): tapping a chip inserts the command text into
+// the shell's input buffer — trailing space, no newline — so the learner
+// still finishes and runs the command themselves.
+//
+// `getPending()` returns the not-yet-completed command names; the parent
+// bumps `version` after every executed command so the chips refresh.
+export default function CommandChips({ send, getPending, version = 0 }) {
+  const pending = useMemo(() => getPending(), [version, getPending])
+
+  return (
+    <div className="command-chips" data-testid="command-chips">
+      {pending.slice(0, MAX_CHIPS).map((name) => (
+        <button
+          key={name}
+          type="button"
+          data-testid={`chip-${name}`}
+          aria-label={`Insert ${name} command`}
+          // preventDefault keeps focus on the terminal; the chip only
+          // inserts text, it never runs the command
+          onPointerDown={(e) => {
+            e.preventDefault()
+            send(name + ' ')
+          }}
+        >
+          {name}
+        </button>
+      ))}
+    </div>
+  )
+}

--- a/src/components/KeyBar.jsx
+++ b/src/components/KeyBar.jsx
@@ -1,0 +1,38 @@
+import React from 'react'
+
+// On-screen helper keys for touch devices (the Termux/Blink extra-keys
+// pattern): keys that are awkward or impossible to reach on mobile soft
+// keyboards. Each press is forwarded to the shell via `send`, which is
+// exactly equivalent to typing the same data.
+const KEYS = [
+  { testId: 'key-tab', label: 'Tab', aria: 'Tab key', data: '\t' },
+  { testId: 'key-up', label: '↑', aria: 'History up', data: '\x1b[A' },
+  { testId: 'key-down', label: '↓', aria: 'History down', data: '\x1b[B' },
+  { testId: 'key-tilde', label: '~', aria: 'Tilde key', data: '~' },
+  { testId: 'key-slash', label: '/', aria: 'Slash key', data: '/' },
+  { testId: 'key-dash', label: '-', aria: 'Dash key', data: '-' },
+  { testId: 'key-dot', label: '.', aria: 'Dot key', data: '.' },
+]
+
+export default function KeyBar({ send }) {
+  return (
+    <div className="key-bar" data-testid="key-bar">
+      {KEYS.map((key) => (
+        <button
+          key={key.testId}
+          type="button"
+          data-testid={key.testId}
+          aria-label={key.aria}
+          // preventDefault keeps the press from stealing focus away from
+          // the terminal (and from dismissing the soft keyboard)
+          onPointerDown={(e) => {
+            e.preventDefault()
+            send(key.data)
+          }}
+        >
+          {key.label}
+        </button>
+      ))}
+    </div>
+  )
+}

--- a/src/components/keybar.test.jsx
+++ b/src/components/keybar.test.jsx
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import React, { act } from 'react'
+import { createRoot } from 'react-dom/client'
+import KeyBar from './KeyBar'
+import CommandChips from './CommandChips'
+import CounterService from '../commands/counter.service'
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true
+
+let container
+let root
+
+beforeEach(() => {
+  window.localStorage.clear()
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  container.remove()
+  window.localStorage.clear()
+})
+
+function render(element) {
+  act(() => root.render(element))
+}
+
+// React listens for the native 'pointerdown' event; jsdom has no
+// PointerEvent constructor so a plain Event with the right type suffices
+function press(el) {
+  act(() => {
+    el.dispatchEvent(new window.Event('pointerdown', { bubbles: true, cancelable: true }))
+  })
+}
+
+describe('KeyBar', () => {
+  it('renders the 7 helper keys with their test ids', () => {
+    render(<KeyBar send={() => {}} />)
+    expect(container.querySelector('[data-testid="key-bar"]')).not.toBeNull()
+    const ids = ['key-tab', 'key-up', 'key-down', 'key-tilde', 'key-slash', 'key-dash', 'key-dot']
+    for (const id of ids) {
+      const button = container.querySelector(`[data-testid="${id}"]`)
+      expect(button).not.toBeNull()
+      expect(button.tagName).toBe('BUTTON')
+      expect(button.getAttribute('aria-label')).toBeTruthy()
+    }
+    expect(container.querySelectorAll('[data-testid="key-bar"] button')).toHaveLength(7)
+  })
+
+  it('sends the right data for each key press', () => {
+    const send = vi.fn()
+    render(<KeyBar send={send} />)
+    press(container.querySelector('[data-testid="key-tab"]'))
+    expect(send).toHaveBeenLastCalledWith('\t')
+    press(container.querySelector('[data-testid="key-up"]'))
+    expect(send).toHaveBeenLastCalledWith('\x1b[A')
+    press(container.querySelector('[data-testid="key-down"]'))
+    expect(send).toHaveBeenLastCalledWith('\x1b[B')
+    press(container.querySelector('[data-testid="key-tilde"]'))
+    expect(send).toHaveBeenLastCalledWith('~')
+    press(container.querySelector('[data-testid="key-slash"]'))
+    expect(send).toHaveBeenLastCalledWith('/')
+    press(container.querySelector('[data-testid="key-dash"]'))
+    expect(send).toHaveBeenLastCalledWith('-')
+    press(container.querySelector('[data-testid="key-dot"]'))
+    expect(send).toHaveBeenLastCalledWith('.')
+    expect(send).toHaveBeenCalledTimes(7)
+  })
+})
+
+describe('CommandChips', () => {
+  it('renders up to 4 pending commands as chips', () => {
+    const getPending = () => ['echo', 'pwd', 'ls', 'cat', 'rm']
+    render(<CommandChips send={() => {}} getPending={getPending} version={0} />)
+    const chips = container.querySelectorAll('[data-testid="command-chips"] button')
+    expect(chips).toHaveLength(4)
+    expect(container.querySelector('[data-testid="chip-echo"]').textContent).toBe('echo')
+    expect(container.querySelector('[data-testid="chip-pwd"]').textContent).toBe('pwd')
+    expect(container.querySelector('[data-testid="chip-rm"]')).toBeNull()
+  })
+
+  it('inserts the command with a trailing space (never runs it)', () => {
+    const send = vi.fn()
+    render(<CommandChips send={send} getPending={() => ['echo']} version={0} />)
+    press(container.querySelector('[data-testid="chip-echo"]'))
+    expect(send).toHaveBeenCalledTimes(1)
+    expect(send).toHaveBeenCalledWith('echo ')
+  })
+
+  it('re-reads getPending when the version prop changes', () => {
+    let pending = ['echo', 'pwd']
+    const getPending = () => pending
+    render(<CommandChips send={() => {}} getPending={getPending} version={0} />)
+    expect(container.querySelector('[data-testid="chip-echo"]')).not.toBeNull()
+
+    pending = ['pwd']
+    render(<CommandChips send={() => {}} getPending={getPending} version={1} />)
+    expect(container.querySelector('[data-testid="chip-echo"]')).toBeNull()
+    expect(container.querySelector('[data-testid="chip-pwd"]')).not.toBeNull()
+  })
+})
+
+describe('CounterService.pendingCommands', () => {
+  it('excludes completed and multi-word entries', () => {
+    const counter = new CounterService()
+    const pending = counter.pendingCommands()
+    expect(pending).toContain('echo')
+    expect(pending).toContain('cd')
+    expect(pending.some((name) => name.includes(' '))).toBe(false)
+    expect(pending).not.toContain('cd ..')
+    expect(pending).not.toContain('cd ~')
+
+    counter.setDone('echo')
+    expect(counter.pendingCommands()).not.toContain('echo')
+    expect(counter.pendingCommands()).toContain('pwd')
+  })
+})

--- a/src/components/terminal.jsx
+++ b/src/components/terminal.jsx
@@ -1,11 +1,23 @@
-import React, { useEffect, useRef } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import { Terminal as XTerm } from '@xterm/xterm'
 import { FitAddon } from '@xterm/addon-fit'
 import '@xterm/xterm/css/xterm.css'
 import commands from '../commands'
+import CounterService from '../commands/counter.service'
 import FileSystem from '../lib/fs'
 import Shell from '../lib/shell'
 import { green, red, white } from '../lib/ansi'
+import KeyBar from './KeyBar'
+import CommandChips from './CommandChips'
+
+// Touch UI gate: coarse pointer (real touch devices and Playwright device
+// emulation) or the ?touch=1 escape hatch for manual desktop testing
+function isTouchUi() {
+  const coarse =
+    typeof window.matchMedia === 'function' &&
+    window.matchMedia('(pointer: coarse)').matches
+  return coarse || window.location.search.includes('touch=1')
+}
 
 const PROMPT = green('user@localhost:~$') + ' '
 
@@ -19,6 +31,12 @@ const GREETING =
 
 export default function Terminal() {
   const containerRef = useRef(null)
+  // forwards key-bar/chip presses into the shell once the effect creates it
+  const sendRef = useRef(null)
+  const [counter] = useState(() => new CounterService())
+  const [touchUi] = useState(isTouchUi)
+  // bumped after every executed command so the chips re-read progress
+  const [version, setVersion] = useState(0)
 
   useEffect(() => {
     const term = new XTerm({
@@ -44,9 +62,13 @@ export default function Terminal() {
       clear: () => term.clear(),
       history: () => ({ data: () => shell.history() }),
     }
-    shell.setCommands(commands(context, fs))
+    shell.setCommands(commands(context, fs, counter))
     shell.onPrint = (plain) => window.__terminalText.push(plain)
-    shell.onCommand = (line) => window.__terminalText.push(line)
+    shell.onCommand = (line) => {
+      window.__terminalText.push(line)
+      setVersion((v) => v + 1)
+    }
+    sendRef.current = (data) => shell.handleData(data)
 
     shell.print(GREETING)
     shell.start()
@@ -57,11 +79,26 @@ export default function Terminal() {
     term.focus()
 
     return () => {
+      sendRef.current = null
       window.removeEventListener('resize', onResize)
       dataListener.dispose()
       term.dispose()
     }
-  }, [])
+  }, [counter])
 
-  return <div className="terminal-container" ref={containerRef} />
+  const send = (data) => sendRef.current && sendRef.current(data)
+
+  return (
+    <div className="app-shell" data-testid="app-shell">
+      <div className="terminal-container" ref={containerRef} />
+      {touchUi && (
+        <CommandChips
+          send={send}
+          getPending={() => counter.pendingCommands()}
+          version={version}
+        />
+      )}
+      {touchUi && <KeyBar send={send} />}
+    </div>
+  )
 }

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -17,6 +17,42 @@ body,
   height: 100vh;
 }
 
+/* Mobile helper-key bar and command suggestion chips */
+.key-bar,
+.command-chips {
+  flex: none;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 8px;
+  background: #111;
+  overflow-x: auto;
+  touch-action: manipulation;
+}
+
+.key-bar button,
+.command-chips button {
+  flex: none;
+  min-width: 44px;
+  min-height: 44px;
+  border: 1px solid #333;
+  background: #222;
+  color: #fff;
+  font-family: Menlo, Monaco, 'Courier New', monospace;
+  font-size: 16px;
+  cursor: pointer;
+  touch-action: manipulation;
+}
+
+.key-bar button {
+  border-radius: 6px;
+}
+
+.command-chips button {
+  border-radius: 22px;
+  padding: 0 16px;
+}
+
 h1 {
 	font-size: 70px;
 	font-style: normal;


### PR DESCRIPTION
## Phase 2 of mobile support: on-screen helper keys + educational command chips

### What's in here
- **`src/components/KeyBar.jsx`** — sticky helper-key row (`Tab ↑ ↓ ~ / - .`), the Termux/Blink extra-keys pattern. Native buttons with aria-labels, 44px minimum targets, horizontal scroll. Presses go through `send(data)` → `shell.handleData`, so a press is exactly equivalent to typing (`'\t'`, `'\x1b[A'`, `'\x1b[B'`, literal chars).
- **`src/components/CommandChips.jsx`** — up to 4 not-yet-completed tutorial commands as chips (Swift Playgrounds insert-don't-run pattern): a tap inserts `cmd ` into the input buffer (trailing space, no `\r`) — it never auto-runs. Refreshes after every executed command via a `version` prop.
- **`src/commands/counter.service.js`** — new `pendingCommands()` (pending, single-word entries only; excludes pseudo-entries like `cd ..`).
- **`src/commands/index.js`** — `commands(context, fs, counter)` now accepts an optional injected CounterService (backward-compatible default).
- **`src/components/terminal.jsx`** — `app-shell` wrapper per shared contract, `sendRef` wiring, version bump in `shell.onCommand`, touch gate computed at mount (`matchMedia('(pointer: coarse)')` or `?touch=1`).
- **`src/css/style.css`** — `.key-bar` / `.command-chips` styles (dark, monospace, 44px targets, `touch-action: manipulation`).
- **`src/components/keybar.test.jsx`** — unit tests for both components and `pendingCommands()` (plain `createRoot` + `act`, no new dependencies).

All test ids and behavior follow the shared contracts (`key-bar`, `key-tab`…`key-dot`, `command-chips`, `chip-<command>`); buttons handle `onPointerDown` with `preventDefault()` so they never steal focus from the terminal.

### Verification
- `npx vitest run` — 73/73 pass (6 files)
- `npm run build` and `npm run lint` — clean
- `npx playwright test --list` — existing 7 specs parse
- Browser e2e runs in CI on this PR (the parallel e2e unit's mobile specs target the test ids above)

### Note for merge coordination
`.app-shell` layout CSS (flex column, terminal height) is owned by the parallel mobile-layout unit; until that merges, `.terminal-container` is still `100vh`, so with `?touch=1` alone the bars sit below the fold. The coordinator dedupes the `app-shell` wrapper at merge.

https://claude.ai/code/session_01P1a7X9z8HnUdhWGSKmEnyE

---
_Generated by [Claude Code](https://claude.ai/code/session_01P1a7X9z8HnUdhWGSKmEnyE)_