### PR TITLE
feat(mobile): keyboard-safe viewport layout and IME-tolerant input

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <link rel="icon" href="/favicon.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover, interactive-widget=resizes-content" />
     <meta name="theme-color" content="#000000" />
     <meta name="description" content="Learn Linux Commands online." />
     <link rel="apple-touch-icon" href="/logo192.png" />

--- a/src/boot.smoke.test.jsx
+++ b/src/boot.smoke.test.jsx
@@ -38,6 +38,14 @@ function stubBrowserApis() {
     window.requestAnimationFrame = (cb) => setTimeout(() => cb(Date.now()), 0)
     window.cancelAnimationFrame = (id) => clearTimeout(id)
   }
+  if (!window.visualViewport) {
+    window.visualViewport = {
+      height: 768,
+      offsetTop: 0,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+    }
+  }
 }
 
 describe('app boot smoke test', () => {

--- a/src/components/terminal.jsx
+++ b/src/components/terminal.jsx
@@ -1,10 +1,11 @@
-import React, { useEffect, useRef } from 'react'
+import React, { useCallback, useEffect, useRef } from 'react'
 import { Terminal as XTerm } from '@xterm/xterm'
 import { FitAddon } from '@xterm/addon-fit'
 import '@xterm/xterm/css/xterm.css'
 import commands from '../commands'
 import FileSystem from '../lib/fs'
 import Shell from '../lib/shell'
+import { useVisualViewport } from '../lib/useVisualViewport'
 import { green, red, white } from '../lib/ansi'
 
 const PROMPT = green('user@localhost:~$') + ' '
@@ -19,6 +20,9 @@ const GREETING =
 
 export default function Terminal() {
   const containerRef = useRef(null)
+  const appShellRef = useRef(null)
+  const termRef = useRef(null)
+  const fitAddonRef = useRef(null)
 
   useEffect(() => {
     const term = new XTerm({
@@ -32,6 +36,8 @@ export default function Terminal() {
     term.loadAddon(fitAddon)
     term.open(containerRef.current)
     fitAddon.fit()
+    termRef.current = term
+    fitAddonRef.current = fitAddon
 
     // window.__terminalText exists solely as a plain-text output hook for the
     // Playwright e2e tests (xterm renders to canvas/DOM that is hard to read)
@@ -60,8 +66,33 @@ export default function Terminal() {
       window.removeEventListener('resize', onResize)
       dataListener.dispose()
       term.dispose()
+      termRef.current = null
+      fitAddonRef.current = null
     }
   }, [])
 
-  return <div className="terminal-container" ref={containerRef} />
+  // Refit xterm and keep the prompt in view whenever the visual viewport
+  // changes (soft keyboard opening/closing, URL bar collapse, pinch-zoom pan)
+  const onViewportChange = useCallback(() => {
+    if (fitAddonRef.current) fitAddonRef.current.fit()
+    if (termRef.current) termRef.current.scrollToBottom()
+  }, [])
+  useVisualViewport(appShellRef, onViewportChange)
+
+  // iOS only opens the soft keyboard from a genuine user gesture; focusing
+  // from any tap on the shell widens the target beyond xterm's own screen
+  const focusTerminal = () => {
+    if (termRef.current) termRef.current.focus()
+  }
+
+  return (
+    <div
+      className="app-shell"
+      data-testid="app-shell"
+      ref={appShellRef}
+      onClick={focusTerminal}
+    >
+      <div className="terminal-container" ref={containerRef} />
+    </div>
+  )
 }

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -6,15 +6,36 @@
 }
 
 html,
-body,
+body {
+  height: 100%;
+  overflow: hidden;
+  overscroll-behavior: none;
+  -webkit-tap-highlight-color: transparent;
+}
+
 #root {
   height: 100%;
 }
 
-/* xterm.js container — fill the viewport so the fit addon sizes correctly */
+/* App box pinned to the visual viewport. The JS hook (useVisualViewport)
+   resizes/translates this element when the soft keyboard opens on iOS;
+   interactive-widget=resizes-content handles Android natively. */
+.app-shell {
+  position: fixed;
+  inset: 0;
+  height: 100%; /* fallback for browsers without dvh */
+  height: 100dvh;
+  display: flex;
+  flex-direction: column;
+  background-color: black;
+}
+
+/* xterm.js container — take all remaining room so the fit addon sizes
+   correctly; min-height: 0 lets it actually shrink inside the flex column */
 .terminal-container {
   width: 100%;
-  height: 100vh;
+  flex: 1 1 auto;
+  min-height: 0;
 }
 
 h1 {

--- a/src/lib/shell.js
+++ b/src/lib/shell.js
@@ -62,13 +62,19 @@ export default class Shell {
     this.showPrompt()
   }
 
+  // Raw input entry point. Besides clean per-key events this also receives
+  // multi-char chunks: pastes, and Android IME composition output (GBoard
+  // commits words/sequences in one onData call). Escape sequences are matched
+  // on the whole chunk; everything else is normalized and walked code point by
+  // code point through the single-char logic, so embedded \r executes and
+  // embedded \x7f deletes.
   handleData(data) {
     if (data === '\x1b[A') return this._historyUp()
     if (data === '\x1b[B') return this._historyDown()
     if (data.startsWith('\x1b')) return // ignore other escape sequences
-    for (const ch of data) {
-      if (ch === '\r') this._enter()
-      else if (ch === '\n') continue // part of pasted \r\n
+    const chunk = data.replace(/\r\n/g, '\r') // CRLF paste must execute once
+    for (const ch of chunk) {
+      if (ch === '\r' || ch === '\n') this._enter()
       else if (ch === '\x7f' || ch === '\b') this._backspace()
       else if (ch === '\t') this._tab()
       else if (ch === '\x03') this._interrupt()

--- a/src/lib/shell.test.js
+++ b/src/lib/shell.test.js
@@ -146,6 +146,58 @@ describe('Shell', () => {
     })
   })
 
+  describe('multi-char chunks (paste / Android IME)', () => {
+    it('lands a printable chunk in the buffer without executing', () => {
+      type(shell, 'echo hi')
+      expect(shell.buffer).toBe('echo hi')
+      expect(shell.history()).toEqual([])
+    })
+
+    it('executes on an embedded \\r and keeps the remainder in the buffer', () => {
+      const echo = vi.fn()
+      shell.setCommands({ echo })
+      type(shell, 'echo one\recho t')
+      expect(echo).toHaveBeenCalledWith('one')
+      expect(shell.buffer).toBe('echo t')
+    })
+
+    it('normalizes a CRLF chunk to a single execution', () => {
+      const echo = vi.fn()
+      shell.setCommands({ echo })
+      type(shell, 'echo one\r\n')
+      expect(echo).toHaveBeenCalledTimes(1)
+      expect(shell.history()).toEqual(['echo one'])
+      expect(shell.buffer).toBe('')
+    })
+
+    it('executes an LF-only paste once', () => {
+      const pwd = vi.fn()
+      shell.setCommands({ pwd })
+      type(shell, 'pwd\n')
+      expect(pwd).toHaveBeenCalledTimes(1)
+      expect(shell.history()).toEqual(['pwd'])
+    })
+
+    it('applies a trailing \\x7f in a chunk as a delete', () => {
+      type(shell, 'pwdd\x7f')
+      expect(shell.buffer).toBe('pwd')
+    })
+
+    it('handles code points outside the BMP without splitting surrogates', () => {
+      type(shell, 'echo 🚀')
+      expect(shell.buffer).toBe('echo 🚀')
+    })
+
+    it('still recognizes escape sequences after a chunk', () => {
+      shell.setCommands({ echo: () => {} })
+      type(shell, 'echo one\r')
+      type(shell, '\x1b[A')
+      expect(shell.buffer).toBe('echo one')
+      type(shell, '\x1b[B')
+      expect(shell.buffer).toBe('')
+    })
+  })
+
   describe('observer hooks', () => {
     it('onPrint receives ANSI-stripped text', () => {
       const seen = []

--- a/src/lib/useVisualViewport.js
+++ b/src/lib/useVisualViewport.js
@@ -1,0 +1,28 @@
+import { useEffect } from 'react'
+
+// Pins the app box to the visual viewport so the soft keyboard never covers
+// the input line or bottom bars. On Android Chrome the viewport meta
+// interactive-widget=resizes-content does the work natively; on iOS Safari the
+// layout viewport never resizes for the keyboard, so we resize manually on
+// visualViewport resize/scroll (height + offsetTop). See MOBILE_PLAN.md.
+export function useVisualViewport(ref, onResize) {
+  useEffect(() => {
+    const vv = window.visualViewport
+    if (!vv || !ref.current) return
+    const el = ref.current
+    const fit = () => {
+      el.style.height = vv.height + 'px'
+      el.style.transform = `translateY(${vv.offsetTop}px)`
+      if (onResize) onResize()
+    }
+    vv.addEventListener('resize', fit)
+    vv.addEventListener('scroll', fit)
+    fit()
+    return () => {
+      vv.removeEventListener('resize', fit)
+      vv.removeEventListener('scroll', fit)
+      el.style.height = ''
+      el.style.transform = ''
+    }
+  }, [ref, onResize])
+}


### PR DESCRIPTION
## Summary

Phase 1 of the mobile plan (see `MOBILE_PLAN.md`): keyboard-safe layout plus input plumbing hardened for Android IME chunks. Desktop behavior is unchanged.

### Layout (keyboard-safe pinning)
- **`index.html`**: viewport meta gains `viewport-fit=cover, interactive-widget=resizes-content` — Android Chrome 108+ shrinks the layout viewport natively when the soft keyboard opens. No `user-scalable=no` / `maximum-scale` (WCAG 1.4.4).
- **`src/lib/useVisualViewport.js`** (new): hook that pins an element to the visual viewport on `resize` + `scroll` (`height` = `vv.height`, `translateY(vv.offsetTop)`) — iOS Safari never resizes the layout viewport for the keyboard, so this is the JS path. No-ops when `visualViewport` is absent.
- **`src/css/style.css`**: `.app-shell` fixed flex column at `100dvh` (with `100%` fallback); `.terminal-container` becomes `flex: 1 1 auto; min-height: 0` (replaces `100vh`); `html, body` get `overflow: hidden`, `overscroll-behavior: none` (kills pull-to-refresh) and transparent tap highlight. Terminal font stays 16px (iOS auto-zoom threshold).
- **`src/components/terminal.jsx`**: renders the shared-contract DOM (`.app-shell` wrapping `.terminal-container`, slot after the container left free for the KeyBar/Chips unit); attaches the hook with `onResize` calling `fitAddon.fit()` + `term.scrollToBottom()`; tap anywhere on the shell calls `term.focus()` inside the gesture (iOS only opens the keyboard from a genuine user gesture). `window.__terminalText` e2e hook and disposal unchanged.

### Input plumbing (IME/paste chunks)
- **`src/lib/shell.js`**: `handleData` now normalizes `\r\n` to `\r` and walks every non-escape chunk code point by code point, so GBoard/IME multi-char commits and pastes insert correctly, embedded `\r` (or lone `\n`) executes once, and embedded `\x7f` deletes.
- **`src/lib/shell.test.js`**: new suite covering printable chunks, embedded `\r` with remainder, CRLF single execution, LF-only paste, trailing `\x7f` delete, astral code points, and escape sequences after chunks.
- **`src/boot.smoke.test.jsx`**: stubs `window.visualViewport` so the hook path runs under jsdom.

## Verification
- `npx vitest run` — 74/74 pass (7 new shell chunk tests)
- `npm run build` and `npm run lint` — clean
- `npx playwright test --list` — existing 7 specs parse; e2e selectors (`.xterm`) unaffected
- Browser e2e runs in CI on this PR — please check the e2e job results, since soft-keyboard behavior itself can only be exercised on devices/emulators.

https://claude.ai/code/session_01P1a7X9z8HnUdhWGSKmEnyE

---
_Generated by [Claude Code](https://claude.ai/code/session_01P1a7X9z8HnUdhWGSKmEnyE)_