### PR TITLE
fix(mobile): word-wrap output to terminal width and stabilize keyboard refit

### DIFF
--- a/src/components/terminal.jsx
+++ b/src/components/terminal.jsx
@@ -37,6 +37,8 @@ export default function Terminal() {
   const fitAddonRef = useRef(null)
   // forwards key-bar/chip presses into the shell once the effect creates it
   const sendRef = useRef(null)
+  // delayed second fit after keyboard show/hide animations settle
+  const settleTimerRef = useRef(null)
   const [counter] = useState(() => new CounterService())
   const [touchUi] = useState(isTouchUi)
   // bumped after every executed command so the chips re-read progress
@@ -62,7 +64,12 @@ export default function Terminal() {
     window.__terminalText = []
 
     const fs = new FileSystem()
-    const shell = new Shell({ write: (s) => term.write(s), fs, prompt: PROMPT })
+    const shell = new Shell({
+      write: (s) => term.write(s),
+      fs,
+      prompt: PROMPT,
+      cols: () => term.cols,
+    })
     const context = {
       echo: (text) => shell.print(text),
       clear: () => term.clear(),
@@ -86,6 +93,7 @@ export default function Terminal() {
 
     return () => {
       sendRef.current = null
+      clearTimeout(settleTimerRef.current)
       window.removeEventListener('resize', onResize)
       dataListener.dispose()
       term.dispose()
@@ -95,10 +103,18 @@ export default function Terminal() {
   }, [counter])
 
   // Refit xterm and keep the prompt in view whenever the visual viewport
-  // changes (soft keyboard opening/closing, URL bar collapse, pinch-zoom pan)
+  // changes (soft keyboard opening/closing, URL bar collapse, pinch-zoom pan).
+  // The second, delayed fit runs after the keyboard animation settles —
+  // fitting mid-animation leaves the canvas sized for a transient viewport,
+  // which shows up as a stale strip along the terminal's right edge.
   const onViewportChange = useCallback(() => {
-    if (fitAddonRef.current) fitAddonRef.current.fit()
-    if (termRef.current) termRef.current.scrollToBottom()
+    const fit = () => {
+      if (fitAddonRef.current) fitAddonRef.current.fit()
+      if (termRef.current) termRef.current.scrollToBottom()
+    }
+    fit()
+    clearTimeout(settleTimerRef.current)
+    settleTimerRef.current = setTimeout(fit, 300)
   }, [])
   useVisualViewport(appShellRef, onViewportChange)
 

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -1,5 +1,3 @@
-@import url(http://fonts.googleapis.com/css?family=Share+Tech+Mono);
-
 * {
   margin: 0;
   padding: 0;
@@ -11,6 +9,7 @@ body {
   overflow: hidden;
   overscroll-behavior: none;
   -webkit-tap-highlight-color: transparent;
+  background-color: black;
 }
 
 #root {
@@ -31,11 +30,18 @@ body {
 }
 
 /* xterm.js container — take all remaining room so the fit addon sizes
-   correctly; min-height: 0 lets it actually shrink inside the flex column */
+   correctly; min-height: 0 lets it actually shrink inside the flex column.
+   Black background hides the sub-cell remainder gutter to the right of the
+   last terminal column. */
 .terminal-container {
   width: 100%;
   flex: 1 1 auto;
   min-height: 0;
+  background-color: black;
+}
+
+.terminal-container .xterm-viewport {
+  background-color: black;
 }
 
 /* Mobile helper-key bar and command suggestion chips */
@@ -49,6 +55,11 @@ body {
   background: #111;
   overflow-x: auto;
   touch-action: manipulation;
+}
+
+/* keep the bottom row clear of the iPhone home indicator */
+.key-bar {
+  padding-bottom: calc(6px + env(safe-area-inset-bottom));
 }
 
 .key-bar button,
@@ -72,218 +83,4 @@ body {
 .command-chips button {
   border-radius: 22px;
   padding: 0 16px;
-}
-
-h1 {
-	font-size: 70px;
-	font-style: normal;
-	font-variant: normal;
-	font-weight: 500;
-	line-height: 26.4px;
-	color: #ecf0f1;
-}
-body{
-  background-color: black;
-}
-.container{
-	width: 100%;
-	height: 100%;
-	position: absolute;
-}
-
-.text{
-	position: absolute;
-	color: #ecf0f1;
-	font-size: 20px;
-	right: 3%;
-	bottom: 1.8%;
-	text-align: right;
-}
-
-.text-box{
-	position: absolute;
-	width: 30%;
-	height: 16%;
-	bottom: 0;
-	margin-left: 2%;
-}
-
-.below{
-	position: absolute;
-	font-size: 16px;
-}
-
-img.background {
-  /* Set rules to fill background */
-  min-height: 100%;
-  min-width: 1024px;
-	
-  /* Set up proportionate scaling */
-  width: 100%;
-  height: auto;
-	
-  /* Set up positioning */
-  position: fixed;
-  top: 0;
-  left: 0;
-}
-
-@media screen and (max-width: 1024px) { /* Specific to this particular image */
-  img.background {
-    left: 50%;
-    margin-left: -512px;   /* 50% */
-  }
-}
-
-.content {
-  position: absolute;
-  top: 20%;
-  left: 15.3%;
-  -webkit-transform: translate(-50%, -50%);
-  transform: translate(-50%, -50%);
-  font-size: 30px;
-  line-height: 40px;
-  font-family: 'Lato', sans-serif;
-  color: #ecf0f1;
-  height: 160px;
-  overflow: hidden;
-}
-
-.visible {
-  font-weight: 600;
-  overflow: hidden;
-  height: 40px;
-  padding: 0 40px;
-}
-
-.visible:before {
-  content: '[';
-  left: 0;
-  line-height: 40px;
-}
-
-.visible:after {
-  content: ']';
-  position: absolute;
-  right: 0;
-  line-height: 40px;
-}
-.visible:after, .visible:before {
-  position: absolute;
-  top: 0;
-  color: #16a085;
-  font-size: 42px;
-  -webkit-animation-name: opacity;
-  -webkit-animation-duration: 2s;
-  -webkit-animation-iteration-count: infinite;
-  animation-name: opacity;
-  animation-duration: 2s;
-  animation-iteration-count: infinite;
-}
-
-.content p {
-  font-family: Orbitron;
-  display: inline;
-  float: left;
-  margin: 0;
-}
-
-.content ul {
-  font-family: Orbitron;
-  margin-top: 0;
-  padding-left: 110px;
-  text-align: left;
-  list-style: none;
-  -webkit-animation-name: change;
-  -webkit-animation-duration: 6s;
-  -webkit-animation-iteration-count: infinite;
-  animation-name: change;
-  animation-duration: 6s;
-  animation-iteration-count: infinite;
-}
-
-.content ul li {
-  line-height: 40px;
-  margin: 0;
-}
-
-@-webkit-keyframes opacity {
-  0%, 100% {
-    opacity: 0;
-  }
-  50% {
-    opacity: 1;
-  }
-}
-@-webkit-keyframes change {
-  0%, 12%, 100% {
-    -webkit-transform: translateY(0);
-            transform: translateY(0);
-  }
-  17%,29% {
-    -webkit-transform: translateY(-25%);
-            transform: translateY(-25%);
-  }
-  34%,46% {
-    -webkit-transform: translateY(-50%);
-            transform: translateY(-50%);
-  }
-  51%,63% {
-    -webkit-transform: translateY(-75%);
-            transform: translateY(-75%);
-  }
-  68%,80% {
-    -webkit-transform: translateY(-50%);
-            transform: translateY(-50%);
-  }
-  85%,97% {
-    -webkit-transform: translateY(-25%);
-            transform: translateY(-25%);
-  }
-}
-@keyframes opacity {
-  0%, 100% {
-    opacity: 0;
-  }
-  50% {
-    opacity: 1;
-  }
-}
-@keyframes change {
-  0%, 12%, 100% {
-    -webkit-transform: translateY(0);
-            transform: translateY(0);
-  }
-  17%,29% {
-    -webkit-transform: translateY(-25%);
-            transform: translateY(-25%);
-  }
-  34%,46% {
-    -webkit-transform: translateY(-50%);
-            transform: translateY(-50%);
-  }
-  51%,63% {
-    -webkit-transform: translateY(-75%);
-            transform: translateY(-75%);
-  }
-  68%,80% {
-    -webkit-transform: translateY(-50%);
-            transform: translateY(-50%);
-  }
-  85%,97% {
-    -webkit-transform: translateY(-25%);
-            transform: translateY(-25%);
-  }
-}
-
-svg {
-  width: 350px;
-  height: 90px;
-  left: 1.7%;
-  display: block;
-  position: absolute;
-  bottom: 3%	;
-  overflow: hidden;
-  margin: 0 auto;
-  background: black;
 }

--- a/src/lib/shell.js
+++ b/src/lib/shell.js
@@ -14,16 +14,50 @@ export function tokenize(line) {
   return tokens
 }
 
+// Wraps text at word boundaries so no rendered line exceeds `width` visible
+// columns. ANSI escape codes are kept intact and count as zero width. Lines
+// already short enough pass through untouched (preserving any alignment
+// padding); words longer than a full line are hard-broken.
+export function wrapToWidth(text, width) {
+  return text
+    .split('\n')
+    .map((line) => {
+      if (stripAnsi(line).length <= width) return line
+      const lines = []
+      let current = ''
+      for (const word of line.split(' ')) {
+        const joined = current ? current + ' ' + word : word
+        if (current && stripAnsi(joined).length > width) {
+          lines.push(current)
+          current = word
+        } else {
+          current = joined
+        }
+        // hard-break oversized words (only safe without embedded ANSI codes)
+        while (stripAnsi(current).length > width && !current.includes('\x1b')) {
+          lines.push(current.slice(0, width))
+          current = current.slice(width)
+        }
+      }
+      if (current) lines.push(current)
+      return lines.join('\n')
+    })
+    .join('\n')
+}
+
 // Terminal-agnostic line discipline: owns the prompt, input buffer, history
 // navigation, Tab completion and command dispatch. Feed it raw input via
 // handleData(data) (e.g. from xterm's onData) and it writes everything it
 // wants displayed through the injected `write` sink.
 export default class Shell {
-  constructor({ write, commands = {}, fs = null, prompt = '$ ' } = {}) {
+  constructor({ write, commands = {}, fs = null, prompt = '$ ', cols = null } = {}) {
     this._sink = write
     this.commands = commands
     this.fs = fs
     this.prompt = prompt
+    // optional provider of the terminal's current column count; when present,
+    // print() word-wraps output instead of letting the terminal break mid-word
+    this._cols = cols
     this.buffer = ''
     this._history = []
     this._historyIndex = null
@@ -47,10 +81,17 @@ export default class Shell {
     this._sink(String(text).replace(/\r?\n/g, '\r\n'))
   }
 
-  // echo-style output: writes text plus a trailing newline
+  // echo-style output: writes text plus a trailing newline, word-wrapped to
+  // the terminal width when a cols provider is available (terminals hard-wrap
+  // mid-word otherwise, which reads badly on narrow phone screens)
   print(text = '') {
     const s = String(text)
-    this.write(s + '\n')
+    const width = typeof this._cols === 'function' ? this._cols() : 0
+    // widths below 10 are treated as bogus (uninitialized terminal) — no wrap
+    const out = width >= 10 ? wrapToWidth(s, width) : s
+    this.write(out + '\n')
+    // observers get the original unwrapped text so substring assertions in
+    // the e2e suite are independent of the device's column count
     if (this.onPrint) this.onPrint(stripAnsi(s))
   }
 

--- a/src/lib/shell.test.js
+++ b/src/lib/shell.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
-import Shell, { tokenize } from './shell'
+import Shell, { tokenize, wrapToWidth } from './shell'
 import { stripAnsi } from './ansi'
 
 const type = (shell, text) => shell.handleData(text)
@@ -214,5 +214,65 @@ describe('Shell', () => {
       run(shell, 'nope')
       expect(seen).toEqual(['echo hi', 'nope'])
     })
+  })
+})
+
+describe('wrapToWidth', () => {
+  it('leaves short lines untouched, including alignment padding', () => {
+    expect(wrapToWidth('ls           done', 40)).toBe('ls           done')
+  })
+
+  it('wraps long lines at word boundaries', () => {
+    const wrapped = wrapToWidth('the quick brown fox jumps over the lazy dog', 15)
+    for (const line of wrapped.split('\n')) {
+      expect(line.length).toBeLessThanOrEqual(15)
+    }
+    expect(wrapped).toBe('the quick brown\nfox jumps over\nthe lazy dog')
+  })
+
+  it('does not count ANSI escape codes toward the width', () => {
+    const colored = '\x1b[1;32mgreen\x1b[0m word here and more words to wrap'
+    const wrapped = wrapToWidth(colored, 20)
+    for (const line of wrapped.split('\n')) {
+      expect(stripAnsi(line).length).toBeLessThanOrEqual(20)
+    }
+    // the escape codes survive intact
+    expect(wrapped).toContain('\x1b[1;32m')
+  })
+
+  it('hard-breaks words longer than the width', () => {
+    const wrapped = wrapToWidth('aaaaaaaaaaaaaaaaaaaaaaaaa', 10)
+    expect(wrapped.split('\n')).toEqual(['aaaaaaaaaa', 'aaaaaaaaaa', 'aaaaa'])
+  })
+
+  it('preserves existing newlines', () => {
+    expect(wrapToWidth('one\ntwo', 40)).toBe('one\ntwo')
+  })
+})
+
+describe('print wrapping', () => {
+  it('wraps output to the cols provider width', () => {
+    const out = []
+    const shell = new Shell({ write: (s) => out.push(s), cols: () => 15 })
+    shell.print('the quick brown fox jumps over the lazy dog')
+    const written = out.join('')
+    for (const line of stripAnsi(written).split('\r\n')) {
+      expect(line.length).toBeLessThanOrEqual(15)
+    }
+  })
+
+  it('onPrint still receives the original unwrapped text', () => {
+    const seen = []
+    const shell = new Shell({ write: () => {}, cols: () => 15 })
+    shell.onPrint = (s) => seen.push(s)
+    shell.print('the quick brown fox jumps over the lazy dog')
+    expect(seen).toEqual(['the quick brown fox jumps over the lazy dog'])
+  })
+
+  it('does not wrap without a cols provider', () => {
+    const out = []
+    const shell = new Shell({ write: (s) => out.push(s) })
+    shell.print('the quick brown fox jumps over the lazy dog')
+    expect(out.join('')).toBe('the quick brown fox jumps over the lazy dog\r\n')
   })
 })


### PR DESCRIPTION
## Problem (from a real iPhone screenshot)

1. Tutorial text hard-wrapped **mid-word** at the column boundary — "launch es", "arg uments", "commands /tasks" — because terminals break lines at exactly N columns with no word awareness, and phone screens are ~40 columns.
2. A **stale rendering strip along the right edge** of the terminal after the keyboard opened — the canvas was fitted mid-keyboard-animation to a transient viewport size.

## Fixes

- **Word-aware wrapping**: `Shell.print` now wraps at word boundaries to the terminal's live column count (injected `cols` provider). ANSI color codes count as zero width; words longer than a line are hard-broken; short lines (including alignment-padded `help` output) pass through untouched. The `onPrint` observer still receives the *unwrapped* text, so the e2e suite's substring assertions are independent of device width.
- **Settle refit**: a second `fit()` runs 300 ms after each visualViewport change, so the canvas ends up sized for the settled viewport instead of a mid-animation one.
- **CSS polish**: black backgrounds on `.terminal-container` and the xterm viewport (hides the sub-cell remainder gutter right of the last column); key bar pads `env(safe-area-inset-bottom)` to clear the iPhone home indicator; deleted ~210 lines of dead 2020-era CSS (background-image marquee, `h1`, `svg` rules for elements that no longer exist) and an `http://` Google-fonts `@import` that was blocked as mixed content on HTTPS.

## Testing
- 88/88 unit tests (8 new: `wrapToWidth` boundaries, ANSI-aware width, hard-break, `print` wrapping + unwrapped observer)
- Build + lint clean; 13 e2e specs parse — CI runs the full desktop + mobile browser suites on this PR

---
_Generated by [Claude Code](https://claude.ai/code/session_01P1a7X9z8HnUdhWGSKmEnyE)_